### PR TITLE
Updated paradata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,29 +2,29 @@
     "license": "CC-BY-NC-SA-4.0",
     "contributors": [
         {
-            "orcid": "0000-0002-6588-2257",
-            "type": "DataCollector",
-            "name": "Davor Krkljus"
+            "name": "Krkljus, Davor",
+            "type": "Annotator",
+            "orcid": "0000-0002-6588-2257"
         },
         {
-            "orcid": "0000-0001-6254-2604",
-            "type": "DataCollector",
-            "name": "Sylvie Tran"
+            "name": "Tran, Sylvie",
+            "type": "Annotator",
+            "orcid": "0000-0001-6254-2604"
         },
         {
-            "orcid": "0000-0002-6329-7492",
+            "name": "Brey, Amelia",
             "type": "DataCurator",
-            "name": "Amelia Brey"
+            "orcid": "0000-0002-6329-7492"
         },
         {
-            "orcid": "0000-0002-2105-525X",
+            "name": "Becker, Hanné",
             "type": "DataCurator",
-            "name": "Hanné Becker"
+            "orcid": "0000-0002-2105-525X"
         },
         {
-            "orcid": "0000-0002-1986-9545",
+            "name": "Hentschel, Johannes",
             "type": "DataCurator",
-            "name": "Johannes Hentschel"
+            "orcid": "0000-0002-1986-9545"
         }
     ],
     "title": "Jacopo Peri – Euridice (1600) (A corpus of annotated scores)",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,127 @@
+cff-version: 1.2.0
+title: 'Jacopo Peri – Euridice (1600) (A corpus of annotated scores)'
+message: >-
+  Please cite this dataset using the metadata from
+  'preferred-citation'.
+type: dataset
+authors:
+  - given-names: Johannes
+    family-names: Hentschel
+    email: johannes.hentschel@bruckneruni.at
+    affiliation: Anton Bruckner University Linz
+    orcid: 'https://orcid.org/0000-0002-1986-9545'
+  - given-names: Yannis
+    family-names: Rammos
+    email: yannis.rammos@epfl.ch
+    affiliation: École Polytechnique Fédérale de Lausanne
+    orcid: 'https://orcid.org/0000-0003-1455-5990'
+  - given-names: Markus
+    family-names: Neuwirth
+    email: markus.neuwirth@bruckneruni.at
+    affiliation: Anton Bruckner University Linz
+    orcid: 'https://orcid.org/0000-0003-1990-052X'
+  - given-names: Martin
+    family-names: Rohrmeier
+    email: martin.rohrmeier@epfl.ch
+    affiliation: École Polytechnique Fédérale de Lausanne
+    orcid: 'https://orcid.org/0000-0002-4323-7257'
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.14996445
+  - type: url
+    value: 'https://zenodo.org/doi/10.5281/zenodo.14996445'
+url: 'https://zenodo.org/doi/10.5281/zenodo.14996445'
+doi: 10.5281/zenodo.14996445
+repository: 'https://github.com/DCMLab/peri_euridice'
+abstract: >-
+  <jats:p>This corpus of annotated MuseScore files has been
+  created within the DCML corpus initiative and employs the
+  DCML harmony annotation standard. It is one out of ~40
+  similar corpora that have been grouped together to the
+  "Distant Listening Corpus" which comes with the data
+  report "A corpus and a modular infrastructure for the
+  empirical study of (an)notated music":
+  https://doi.org/10.1038/s41597-025-04976-z</jats:p>
+keywords:
+  - expert-annotated dataset
+  - tonal harmony
+  - music research
+  - music theory
+  - music analysis
+  - music history
+  - computational musicology
+  - corpus studies
+  - corpora
+  - symbolic dataset
+  - scores
+  - annotated dataset
+  - harmony
+  - key annotations
+  - chord annotations
+  - phrase annotations
+  - cadence annotations
+  - common practice
+  - research data management
+license: CC-BY-NC-4.0
+version: v2.3
+date-released: '2025-03-15'
+preferred-citation:
+  authors:
+    - given-names: Johannes
+      family-names: Hentschel
+      email: johannes.hentschel@bruckneruni.at
+      affiliation: Anton Bruckner University Linz
+      orcid: 'https://orcid.org/0000-0002-1986-9545'
+    - given-names: Yannis
+      family-names: Rammos
+      email: yannis.rammos@epfl.ch
+      affiliation: École Polytechnique Fédérale de Lausanne
+      orcid: 'https://orcid.org/0000-0003-1455-5990'
+    - given-names: Markus
+      family-names: Neuwirth
+      email: markus.neuwirth@bruckneruni.at
+      affiliation: Anton Bruckner University Linz
+      orcid: 'https://orcid.org/0000-0003-1990-052X'
+    - given-names: Martin
+      family-names: Rohrmeier
+      email: martin.rohrmeier@epfl.ch
+      affiliation: École Polytechnique Fédérale de Lausanne
+      orcid: 'https://orcid.org/0000-0002-4323-7257'
+  title: >-
+    A corpus and a modular infrastructure for the empirical study of (an)notated
+    music
+  doi: 10.1038/s41597-025-04976-z
+  url: 'https://doi.org/10.1038/s41597-025-04976-z'
+  identifiers:
+    - type: doi
+      value: 10.1038/s41597-025-04976-z
+    - type: url
+      value: 'https://doi.org/10.1038/s41597-025-04976-z'
+    - type: other
+      value: 'urn:issn:2052-4463'
+  type: article
+  journal: Scientific Data
+  issn: 2052-4463
+  publisher:
+    name: Springer Nature
+  volume: 12
+  issue: 1
+  year: 2025
+  month: 4
+  start: 685
+  abstract: >-
+    <jats:p>The present corpus is the outcome of a long-term collaborative effort 
+    to produce analytically annotated music scores suitable for the
+    computer-assisted study of European compositions since 1600. With 1283
+    analytically annotated, symbolically encoded music scores by 36 composers,
+    our corpus amounts to one of the largest published resources of its kind. At
+    the same time, it provides a modular digital infrastructure for the
+    accountable, collaborative curation of annotated scores (“sheet music”). All
+    annotations were created and reviewed by a team of trained music theorists,
+    who collaborated online using the git version control software according to
+    a formally codified workflow. To improve the consistency of analytical
+    practices given the diversity of represented eras and genres, the corpus has
+    been automatically parsed for notational well-formedness and cross-reviewed
+    by annotators for adherence to our music-analytical guidelines. The
+    computational infrastructure has been designed with “data persistence” and
+    open access in mind.</jats:p>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ and serves as welcome page for both
 
 For information on how to obtain and use the dataset, please refer to [this documentation page](https://dcmlab.github.io/peri_euridice/introduction).
 
+When you use (parts of) this dataset in your work, please read and cite the accompanying data report:
+
+_Hentschel, J., Rammos, Y., Neuwirth, M., & Rohrmeier, M. (2025). A corpus and a modular infrastructure for the 
+empirical study of (an)notated music. Scientific Data, 12(1), 685. https://doi.org/10.1038/s41597-025-04976-z_
+
 # Jacopo Peri – Euridice (1600) (A corpus of annotated scores)
 
 This is, decisively, the oldest surviving opera; the first opera, the lost Dafne, was written by the same composer. The
@@ -90,7 +95,7 @@ Please [create an issue](https://github.com/DCMLab/peri_euridice/issues) and/or 
 
 ## Cite as
 
-> Johannes Hentschel, Yannis Rammos, Markus Neuwirth, & Martin Rohrmeier. (2025). Jacopo Peri – Euridice (1600) (A corpus of annotated scores) [Data set]. Zenodo. https://doi.org/10.5281/zenodo.14996445
+> Hentschel, J., Rammos, Y., Neuwirth, M., & Rohrmeier, M. (2025). A corpus and a modular infrastructure for the empirical study of (an)notated music. Scientific Data, 12(1), 685. https://doi.org/10.1038/s41597-025-04976-z
 
 ## License
 


### PR DESCRIPTION
This is a README file for a data repository originating from the [DCML corpus initiative](https://github.com/DCMLab/dcml_corpora)
and serves as welcome page for both 

* the GitHub repo [https://github.com/DCMLab/peri_euridice](https://github.com/DCMLab/peri_euridice) and the corresponding
* documentation page [https://dcmlab.github.io/peri_euridice](https://dcmlab.github.io/peri_euridice)

For information on how to obtain and use the dataset, please refer to [this documentation page](https://dcmlab.github.io/peri_euridice/introduction).

When you use (parts of) this dataset in your work, please read and cite the accompanying data report:

_Hentschel, J., Rammos, Y., Neuwirth, M., & Rohrmeier, M. (2025). A corpus and a modular infrastructure for the 
empirical study of (an)notated music. Scientific Data, 12(1), 685. https://doi.org/10.1038/s41597-025-04976-z_

# Jacopo Peri – Euridice (1600) (A corpus of annotated scores)

This is, decisively, the oldest surviving opera; the first opera, the lost Dafne, was written by the same composer. The
Greek myth of Orpheus and Eurydice was a powerful inspiration for the earliest opera composers, having also been adapted
in the few years after by Giulio Caccini (Euridice, 1602) and Claudio Monteverdi (Orfeo, 1607, the most widely performed
of these). Peri, Caccini, and (likely) librettist Ottavio Rinuccini were all members of the Florentine Camerata, a group
which sought to return Western music to its Ancient Greek roots by supplanting the lush choral counterpoint of the day
with bare solo singing over simple accompaniment, often using speech-like prosody. It is interesting to observe,
compared to later opera, how seldom vocal virtuosity is highlighted: we do not see the contrast of elaborate aria and
dry recitative that would be established as a convention of the form soon after. This is one of the oldest works in the
DCML corpora (Sweelinck's Fantasia cromatica may or may not be older), and its analysis reflects, in nearly the simplest
of possible uses, the frameworks that continued to emerge in tonal harmony for centuries after.

## Getting the data

* download repository as a [ZIP file](https://github.com/DCMLab/peri_euridice/archive/main.zip)
* download a [Frictionless Datapackage](https://specs.frictionlessdata.io/data-package/) that includes concatenations
  of the TSV files in the four folders (`measures`, `notes`, `chords`, and `harmonies`) and a JSON descriptor:
  * [peri_euridice.zip](https://github.com/DCMLab/peri_euridice/releases/latest/download/peri_euridice.zip)
  * [peri_euridice.datapackage.json](https://github.com/DCMLab/peri_euridice/releases/latest/download/peri_euridice.datapackage.json)
* clone the repo: `git clone https://github.com/DCMLab/peri_euridice.git` 


## Data Formats

Each piece in this corpus is represented by five files with identical name prefixes, each in its own folder. 
For example, the *Prologo* has the following files:

* `MS3/peri_euridice_scene_0.mscx`: Uncompressed MuseScore 3.6.2 file including the music and annotation labels.
* `notes/peri_euridice_scene_0.notes.tsv`: A table of all note heads contained in the score and their relevant features (not each of them represents an onset, some are tied together)
* `measures/peri_euridice_scene_0.measures.tsv`: A table with relevant information about the measures in the score.
* `chords/peri_euridice_scene_0.chords.tsv`: A table containing layer-wise unique onset positions with the musical markup (such as dynamics, articulation, lyrics, figured bass, etc.).
* `harmonies/peri_euridice_scene_0.harmonies.tsv`: A table of the included harmony labels (including cadences and phrases) with their positions in the score.

Each TSV file comes with its own JSON descriptor that describes the meanings and datatypes of the columns ("fields") it contains,
follows the [Frictionless specification](https://specs.frictionlessdata.io/tabular-data-resource/),
and can be used to validate and correctly load the described file. 

### Opening Scores

After navigating to your local copy, you can open the scores in the folder `MS3` with the free and open source score
editor [MuseScore](https://musescore.org). Please note that the scores have been edited, annotated and tested with
[MuseScore 3.6.2](https://github.com/musescore/MuseScore/releases/tag/v3.6.2). 
MuseScore 4 has since been released which renders them correctly but cannot store them back in the same format.

### Opening TSV files in a spreadsheet

Tab-separated value (TSV) files are like Comma-separated value (CSV) files and can be opened with most modern text
editors. However, for correctly displaying the columns, you might want to use a spreadsheet or an addon for your
favourite text editor. When you use a spreadsheet such as Excel, it might annoy you by interpreting fractions as
dates. This can be circumvented by using `Data --> From Text/CSV` or the free alternative
[LibreOffice Calc](https://www.libreoffice.org/download/download/). Other than that, TSV data can be loaded with
every modern programming language.

### Loading TSV files in Python

Since the TSV files contain null values, lists, fractions, and numbers that are to be treated as strings, you may want
to use this code to load any TSV files related to this repository (provided you're doing it in Python). After a quick
`pip install -U ms3` (requires Python 3.10 or later) you'll be able to load any TSV like this:

```python
import ms3

labels = ms3.load_tsv("harmonies/peri_euridice_scene_0.harmonies.tsv")
notes = ms3.load_tsv("notes/peri_euridice_scene_0.notes.tsv")
```


## Version history

See the [GitHub releases](https://github.com/DCMLab/peri_euridice/releases).

## Questions, Suggestions, Corrections, Bug Reports

Please [create an issue](https://github.com/DCMLab/peri_euridice/issues) and/or feel free to fork and submit pull requests.

## Cite as

> Hentschel, J., Rammos, Y., Neuwirth, M., & Rohrmeier, M. (2025). A corpus and a modular infrastructure for the empirical study of (an)notated music. Scientific Data, 12(1), 685. https://doi.org/10.1038/s41597-025-04976-z

## License

Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License ([CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)).